### PR TITLE
Fixed Issue #4 (charmap) issue on Windows systems

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-knowledge-graph"
-version = "0.6.0"
+version = "0.6.1"
 description = "Takes a text document and generates an interactive knowledge graph"
 authors = [{ name = "Robert McDermott", email = "robert.c.mcdermott@gmail.com" }, ]
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.12"
 
 [[package]]
 name = "ai-knowledge-graph"
-version = "0.6.0"
+version = "0.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "networkx" },

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.12"
 
 [[package]]
 name = "ai-knowledge-graph"
-version = "0.5.7"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "networkx" },


### PR DESCRIPTION
Fix Windows encoding issues in knowledge graph visualization

## Issue
Windows users were experiencing UnicodeEncodeError when generating knowledge graphs with certain input files. The error occurred during HTML generation with the message: 'charmap' codec can't encode characters in position 263607-263621: character maps to <undefined>

## Root Cause
The PyVis library was using the system's default encoding when writing HTML files. On Windows, this is typically 'cp1252' (Windows-1252), which has limited Unicode support compared to UTF-8 that's used on Mac/Linux systems.

## Fix
Modified the [_save_and_modify_html](cci:1://file:///Users/rmcdermo/mycode/ai-knowledge-graph/src/knowledge_graph/visualization.py:324:0-362:44) function to:
1. Use PyVis's internal HTML generation capabilities instead of letting it write to a file
2. Directly access the generated HTML content in memory
3. Write the file ourselves with explicit UTF-8 encoding

This bypasses the encoding issue completely by taking control of the file writing process with proper UTF-8 handling, ensuring consistent behavior across all operating systems.

## Testing
Confirmed working on both Mac OS and Windows environments with the same input data.


Fixes issue: #4 